### PR TITLE
Upgrading slf4j

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: false
 language: java
 jdk:
-  - oraclejdk8
+  - openjdk8
 before_install: 'mvn -version'
 install: 'mvn clean install'
 

--- a/modules/cpr/pom.xml
+++ b/modules/cpr/pom.xml
@@ -213,19 +213,19 @@
         </dependency>
 
         <dependency>
-            <groupId>org.atmosphere</groupId>
+            <groupId>com.vaadin.external.atmosphere</groupId>
             <artifactId>atmosphere-compat-jbossweb</artifactId>
             <version>${compat-version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>org.atmosphere</groupId>
+            <groupId>com.vaadin.external.atmosphere</groupId>
             <artifactId>atmosphere-compat-tomcat</artifactId>
             <version>${compat-version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>org.atmosphere</groupId>
+            <groupId>com.vaadin.external.atmosphere</groupId>
             <artifactId>atmosphere-compat-tomcat7</artifactId>
             <version>${compat-version}</version>
             <scope>provided</scope>

--- a/modules/native/pom.xml
+++ b/modules/native/pom.xml
@@ -141,17 +141,17 @@
             <scope>compile</scope>
         </dependency>
         <dependency>
-            <groupId>org.atmosphere</groupId>
+            <groupId>com.vaadin.external.atmosphere</groupId>
             <artifactId>atmosphere-compat-jbossweb</artifactId>
             <version>${compat-version}</version>
         </dependency>
         <dependency>
-            <groupId>org.atmosphere</groupId>
+            <groupId>com.vaadin.external.atmosphere</groupId>
             <artifactId>atmosphere-compat-tomcat</artifactId>
             <version>${compat-version}</version>
         </dependency>
         <dependency>
-            <groupId>org.atmosphere</groupId>
+            <groupId>com.vaadin.external.atmosphere</groupId>
             <artifactId>atmosphere-compat-tomcat7</artifactId>
             <version>${compat-version}</version>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -613,7 +613,7 @@
         <felix-version>2.3.7</felix-version>
         <ahc.version>1.7.7</ahc.version>
         <slf4j-impl-version>1.6.1</slf4j-impl-version>
-        <slf4j-version>1.8.0.beta4</slf4j-version>
+        <slf4j-version>1.8.0-beta4</slf4j-version>
         <logback-version>1.1.2</logback-version>
         <jbossaswebsockets-version>0.5</jbossaswebsockets-version>
         <compat-version>2.0.1-vaadin1</compat-version>

--- a/pom.xml
+++ b/pom.xml
@@ -613,7 +613,7 @@
         <felix-version>2.3.7</felix-version>
         <ahc.version>1.7.7</ahc.version>
         <slf4j-impl-version>1.6.1</slf4j-impl-version>
-        <slf4j-version>1.7.7</slf4j-version>
+        <slf4j-version>1.8.0.beta4</slf4j-version>
         <logback-version>1.1.2</logback-version>
         <jbossaswebsockets-version>0.5</jbossaswebsockets-version>
         <compat-version>2.0.1-vaadin1</compat-version>


### PR DESCRIPTION
Versions prior to 1.8.0.beta2 will give alert for CVE-2018-8088

For me it looks like false positive, i.e. not possible to exploit in practice here.