### PR TITLE
Update slf4j to latest

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -539,7 +539,7 @@
         <felix-version>2.4.0</felix-version>
         <ahc.version>1.9.33</ahc.version>
         <slf4j-impl-version>1.7.13</slf4j-impl-version>
-        <slf4j-version>1.7.13</slf4j-version>
+        <slf4j-version>1.8.0-beta4</slf4j-version>
         <logback-version>1.1.2</logback-version>
         <compat-version>2.0.1</compat-version>
         <shiro-version>1.2.4</shiro-version>


### PR DESCRIPTION
From @TatuLund :Versions prior to 1.8.0.beta2 will give alert for CVE-2018-8088

For me it looks like false positive, i.e. not possible to exploit in practice here.