### PR TITLE
fix: make endAsyncContext more robust

### DIFF
--- a/modules/cpr/src/main/java/org/atmosphere/container/Servlet30CometSupport.java
+++ b/modules/cpr/src/main/java/org/atmosphere/container/Servlet30CometSupport.java
@@ -119,17 +119,24 @@ public class Servlet30CometSupport extends AsynchronousProcessor {
     }
 
     public void endAsyncContext(AtmosphereRequest request){
-        AsyncContext asyncContext = (AsyncContext) request.getAttribute(FrameworkConfig.ASYNC_CONTEXT);
-        if (asyncContext != null) {
-            try {
-                asyncContext.complete();
-            } catch (IllegalStateException ex) {
-                // Already completed. Jetty throw an exception on shutdown with log
+        Object attribute = null;
+        try {
+             attribute = request.getAttribute(FrameworkConfig.ASYNC_CONTEXT);
+        } catch (Exception e) {
+             logger.warn("Exception occurred in getting attribute from request object", e);
+        }
+        if (attribute != null && attribute instanceof AsyncContext) {
+            AsyncContext asyncContext = (AsyncContext) attribute;
+            if (asyncContext != null) {
                 try {
-                    logger.trace("Already resumed!", ex);
-                } catch (Exception ex2){};
-            } finally {
-                request.removeAttribute(FrameworkConfig.ASYNC_CONTEXT);
+                    asyncContext.complete();
+                } catch (IllegalStateException ex) {
+                    // Already completed. Jetty throw an exception on shutdown with log
+                    try {
+                        logger.trace("Already resumed!", ex);
+                    } catch (Exception ex2) {
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
Adopt changes from 2.4.30, especially from https://github.com/vaadin/atmosphere/commit/a205b45a4dba105bd6eebba9481590c1057f9d6c
