### PR TITLE
fix: Do not log a warning with stack trace when a session expires

### DIFF
--- a/modules/runtime/src/main/java/org/atmosphere/runtime/AsynchronousProcessor.java
+++ b/modules/runtime/src/main/java/org/atmosphere/runtime/AsynchronousProcessor.java
@@ -163,7 +163,6 @@ AsynchronousProcessor implements AsyncSupport<AtmosphereResourceImpl> {
                 }
             } catch (IllegalStateException ex) {
                 AtmosphereResourceImpl r = AtmosphereResourceImpl.class.cast(req.resource());
-                logger.warn("Session Expired for {}. Closing the connection", req.uuid(), ex);
                 if (r != null) {
                     logger.trace("Ending request for {}", r.uuid());
                     endRequest(r, true);


### PR DESCRIPTION
Fixes https://github.com/vaadin/flow/issues/9367